### PR TITLE
Navigation Menu Entries Overlap in Mobile View

### DIFF
--- a/source/style.css
+++ b/source/style.css
@@ -224,7 +224,7 @@ footer {
 
 #navigation li
 {
-    display:         inline;
+    display:         inline-block;
     list-style-type: none;
     padding:   1ex;
     -moz-border-radius: 0.5ex;


### PR DESCRIPTION
I noticed that the navigation menu items were vertically overlapping when in mobile view (< 840 px wide).  Changing the #navigation li's display type (/src/style.css:line225) from "inline" to  "inline block" fixes this.
![inline](https://cloud.githubusercontent.com/assets/7515918/8269281/077a9498-1771-11e5-88b4-1c43aaa9e180.png)
![inline-block](https://cloud.githubusercontent.com/assets/7515918/8269280/0777ac06-1771-11e5-9be3-9e962f94df92.png)

