### PR TITLE
Issue #57 - Resources Tab Nav Issues

### DIFF
--- a/includes/footer
+++ b/includes/footer
@@ -16,7 +16,7 @@
       </section>
 
       <section class="col-sm-6 col-md-5ths">
-        <h4><a href="/references/">References</a></h4>
+        <h4><a href="/resources/">Resources</a></h4>
         <ul class="shush-list">
           <li><a href="/getting-started/">Getting started</a></li>
           <li><a href="https://doc.perl6.org/">Perl&nbsp;6 Documentation</a></li>

--- a/includes/footer
+++ b/includes/footer
@@ -23,7 +23,7 @@
           <li><a href="https://doc.perl6.org/language/5to6">Perl&nbsp;5 to Perl 6</a>,
               an introduction for Perl&nbsp;5 programmers</li>
         </ul>
-          <a href="/references/" class="btn btn-success">More</a>
+          <a href="/resources/" class="btn btn-success">More</a>
       </section>
 
       <section class="col-sm-6 col-md-5ths">

--- a/includes/footer
+++ b/includes/footer
@@ -16,14 +16,14 @@
       </section>
 
       <section class="col-sm-6 col-md-5ths">
-        <h4><a href="/documentation/">Documentation</a></h4>
+        <h4><a href="/references/">References</a></h4>
         <ul class="shush-list">
           <li><a href="/getting-started/">Getting started</a></li>
           <li><a href="https://doc.perl6.org/">Perl&nbsp;6 Documentation</a></li>
           <li><a href="https://doc.perl6.org/language/5to6">Perl&nbsp;5 to Perl 6</a>,
               an introduction for Perl&nbsp;5 programmers</li>
         </ul>
-          <a href="/documentation/" class="btn btn-success">More</a>
+          <a href="/references/" class="btn btn-success">More</a>
       </section>
 
       <section class="col-sm-6 col-md-5ths">

--- a/includes/menu-nav
+++ b/includes/menu-nav
@@ -20,8 +20,8 @@
           ><a href="/community/">Community</a></li>%]
         [% item docs <li id="nav-docs" {{ class="active"}}
           ><a href="http://docs.perl6.org">Documentation</a></li> %]
-        [% item docs <li id="nav-res" {{ class="active"}}
-          ><a href="/documentation/">Resources</a></li> %]
+        [% item res <li id="nav-res" {{ class="active"}}
+          ><a href="/resources/">Resources</a></li> %]
         [% item specs <li id="nav-specs" {{ class="active"}}
           ><a href="/specification/">Design</a></li> %]
         [% item compilers <li id="nav-compilers"{{ class="active"}}

--- a/source/getting-started/index.html
+++ b/source/getting-started/index.html
@@ -25,7 +25,7 @@
                 to build and install Rakudo Star, a Perl 6 distribution
                 with a number of useful modules included.</li>
             <li><strong>Read about Perl 6</strong> — explore the
-                <a href="/documentation/">documentation</a>
+                <a href="/references/">documentation</a>
                 to start learning Perl 6.</li>
             <li><strong>Find available modules</strong> — use the <tt>panda</tt>
               installer (comes with Rakudo Star) to install modules listed at the

--- a/source/getting-started/index.html
+++ b/source/getting-started/index.html
@@ -25,7 +25,7 @@
                 to build and install Rakudo Star, a Perl 6 distribution
                 with a number of useful modules included.</li>
             <li><strong>Read about Perl 6</strong> — explore the
-                <a href="/references/">documentation</a>
+                <a href="/resources/">documentation</a>
                 to start learning Perl 6.</li>
             <li><strong>Find available modules</strong> — use the <tt>panda</tt>
               installer (comes with Rakudo Star) to install modules listed at the

--- a/source/resources/index.html
+++ b/source/resources/index.html
@@ -1,6 +1,6 @@
 [% setvar title Perl&nbsp;6 Documentation %]
 
-[% menu nav docs %]
+[% menu nav res %]
 
 <header id="subpage-header" class="lead well">
     [% include camelia %]


### PR DESCRIPTION
I've removed the duplicate reference in the nav for the Documentation and Resources links (to fix the multiple highlighting), and updated the source/documentation folder to source/resources as well as updated the URL in the navigation to reflect the change. I also replaced the link to Documentation in the footer and changed it to Resources.