### PR TITLE
doc.perl6.org -> docs.perl6.org

### DIFF
--- a/includes/menu-nav
+++ b/includes/menu-nav
@@ -33,7 +33,7 @@
         [% item whatever <li id="nav-whatever"{{ class="active"}}
           ><a href="/whatever/">Whatever</a></li> %]
         [% item faq <li id="nav-faq"{{ class="active"}}
-          ><a href="https://doc.perl6.org/language/faq">FAQ</a></li> %]
+          ><a href="https://docs.perl6.org/language/faq">FAQ</a></li> %]
       </ul>
     </div>
   </div>


### PR DESCRIPTION
https://doc.perl6.org/language/faq redirects to https://docs.perl6.org/language/faq  
Update the link.