### PR TITLE
Update the Rakudo Star download link / description

### DIFF
--- a/source/downloads/index.html
+++ b/source/downloads/index.html
@@ -20,11 +20,9 @@
 
         <h3 class="trim-top">Installing from binaries</h3>
 
-        <p>Windows users can directly install the most recent 64 bit or 32 bit MSI of Rakudo Star from the download directory</p>
+        <p>Windows and macOS users can directly install the most recent version of Rakudo Star from the downloads section.</p>
 
-        <p>Mac users can directly install using the most recent .dmg from the same location</p>
-
-        <p><a href="https://rakudo.perl6.org/downloads/star/">https://rakudo.perl6.org/downloads/star</a></p>
+        <p><a href="https://rakudo.org/files/">https://rakudo.org/files/</a></p>
 
         <p>Docker users can directly install with <tt>docker pull rakudo-star</tt> </p>
 


### PR DESCRIPTION
I believe this linked download page for Rakudo Star is more user friendly and nicer looking than the previously linked downloads directory. The description has also been tweaked a little to better describe the link.