### PR TITLE
DO NOT MERGE WITHOUT DISCUSSION

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -35,7 +35,7 @@
       <p>Hi, my name is Camelia.  I'm the spokesbug for Perl&nbsp;6,
         the plucky little sister of <a href="https://www.perl.org/">Perl&nbsp;5</a>.
         Like her world-famous big
-        sister, Perl&nbsp;6 intends to carry forward the high ideals of
+        sister, Perl&nbsp;6, now nicknamed "Raku", intends to carry forward the high ideals of
         the Perl community. Perl&nbsp;6 is
         currently being developed by a team of dedicated and enthusiastic
         volunteers. You can help too. The only requirement is that you know

--- a/source/index.html
+++ b/source/index.html
@@ -35,7 +35,7 @@
       <p>Hi, my name is Camelia.  I'm the spokesbug for Perl&nbsp;6,
         the plucky little sister of <a href="https://www.perl.org/">Perl&nbsp;5</a>.
         Like her world-famous big
-        sister, Perl&nbsp;6, now nicknamed "Raku", intends to carry forward the high ideals of
+        sister, Perl&nbsp;6, now nicknamed by some to be "Raku", intends to carry forward the high ideals of
         the Perl community. Perl&nbsp;6 is
         currently being developed by a team of dedicated and enthusiastic
         volunteers. You can help too. The only requirement is that you know


### PR DESCRIPTION
Given that tempers are high about this discussion I don't suggest merging this (or anything similar) right now.

I think do need a one mild reference to "Raku" on the home page at some point as something extra and not replacing any current perl 6 use. Perl 6 as a name isn't going away.

It seems to me that "nickname" fits in with alias or stage name and "little sister".