### PR TITLE
pin deps

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -7,8 +7,8 @@
     ],
     "auth": "zef:librasteve",
     "depends": [
-        "Air",
-        "Air::Plugin::Hilite"
+        "Air:ver<0.0.29>:auth<zef:librasteve>",
+        "Air::Plugin::Hilite:ver<0.0.5>:auth<zef:librasteve>"
     ],
     "build-depends": [],
     "provides": {


### PR DESCRIPTION
pinning dependencies, particularly to gate recent changes to Cromponent and Rainbow so that we can test