### PR TITLE
Standardize on --/test for local prereqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ Install raku - eg. from rakubrew, then:
 Install Cro & Air
 
 ```
-zef install --/test cro
-zef install Air
+zef install --/test cro Air
 ```
 
 Red is not used in this build.


### PR DESCRIPTION
I understand the desire to use --/test for cro - let's standardize on it for Air as well to simplify the instructions and not have to explain why we do it for one and not the other.
